### PR TITLE
Set noEmitHelpers to avoid __extends()

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
+    "noEmitHelpers": true,
     "moduleResolution": "node"
   },
   "files": [


### PR DESCRIPTION
TypeScript creates an `__extends` function which [breaks most of apps in {N}](https://github.com/NativeScript/nativescript-dev-webpack/issues/8).

A simple fix is settings to `noEmitHelpers` to true.
